### PR TITLE
Now using version's hash code instead of v. number.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Bump version and push tag
         if: ${{ github.event_name == 'push' && !env.SKIP_TAG_RELEASE }} # only on merge and when '#skip' isn't found in the commit message
-        uses: anothrNick/github-tag-action@1.36.0
+        uses: anothrNick/github-tag-action@ce4b5ffa38e072fa7a901e417253c438fcc2ccce
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch


### PR DESCRIPTION
Change has been made to prevent future problems in case changes to the code of that specific version happen.